### PR TITLE
Put reset and drop-off buttons side-by-side on farmer search page

### DIFF
--- a/MilkBuddy/app/src/main/res/layout/activity_farmer_search.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_farmer_search.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-   <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <TableRow
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal">
+       <LinearLayout
+           android:layout_width="match_parent"
+           android:layout_height="wrap_content"
+           android:gravity="center"
+           android:orientation="horizontal">
 
         <Button
+            android:id="@+id/button1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
             android:text="Reset"
             android:textSize="15sp"
-            android:id="@+id/button"
             android:background="#EDF0F0F0"/>
 
         <Button
+            android:id="@+id/button2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
             android:text="Drop-Off"
             android:textSize="15sp"
-            android:id="@+id/button2"
             android:background="#EDF0F0F0"/>
 
-    </TableRow>
+       </LinearLayout>
 
     <TextView
         android:id="@+id/textView1"
@@ -39,7 +39,6 @@
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
         android:layout_marginTop="10dp"
-        android:layout_marginBottom="10dp"
         android:text="Search for a Farmer"
         android:textColor="#000000"
         android:textSize="20sp"/>
@@ -48,7 +47,6 @@
         android:id="@+id/farmerSearchView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="1dp"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"/>
 
@@ -71,7 +69,7 @@
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
         android:layout_marginTop="10dp"
-        android:layout_marginBottom="10dp" />
+        android:layout_marginBottom="10dp"/>
 
     <CheckBox
         android:id="@+id/checkBox1"
@@ -93,7 +91,7 @@
 
 
 
- <ListView
+    <ListView
         android:id="@+id/list_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/MilkBuddy/app/src/main/res/layout/activity_farmer_search.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_farmer_search.xml
@@ -12,7 +12,7 @@
            android:orientation="horizontal">
 
         <Button
-            android:id="@+id/button1"
+            android:id="@+id/button2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="8dp"
@@ -21,7 +21,7 @@
             android:background="#EDF0F0F0"/>
 
         <Button
-            android:id="@+id/button2"
+            android:id="@+id/button1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="8dp"

--- a/MilkBuddy/app/src/main/res/layout/activity_farmer_search.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_farmer_search.xml
@@ -5,17 +5,31 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <Button
-        android:id="@+id/button1"
+    <TableRow
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Drop-Off" />
+        android:gravity="center"
+        android:orientation="horizontal">
 
-    <Button
-        android:id="@+id/button2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="Reset" />
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="Reset"
+            android:textSize="15sp"
+            android:id="@+id/button"
+            android:background="#EDF0F0F0"/>
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="Drop-Off"
+            android:textSize="15sp"
+            android:id="@+id/button2"
+            android:background="#EDF0F0F0"/>
+
+    </TableRow>
 
     <TextView
         android:id="@+id/textView1"
@@ -24,7 +38,7 @@
         android:gravity="center"
         android:layout_marginLeft="20dp"
         android:layout_marginRight="20dp"
-        android:layout_marginTop="20dp"
+        android:layout_marginTop="10dp"
         android:layout_marginBottom="10dp"
         android:text="Search for a Farmer"
         android:textColor="#000000"
@@ -34,6 +48,7 @@
         android:id="@+id/farmerSearchView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="1dp"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"/>
 


### PR DESCRIPTION
This is what it should look like:

![image](https://user-images.githubusercontent.com/43508320/75288234-e6d5f700-57e9-11ea-886c-76ff40ff3f97.png)

This should create more room on the farmer search page since the buttons are now side-by-side.
