### PR TITLE
All back buttons done and added completion page for the end of the flow

### DIFF
--- a/MilkBuddy/app/src/main/AndroidManifest.xml
+++ b/MilkBuddy/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".ExportPlantData"></activity>
+        <activity android:name=".Completed"></activity>
+        <activity android:name=".ExportPlantData" />
         <activity android:name=".ReceiverCollection" />
         <activity android:name=".FarmerCollection" />
         <activity android:name=".ExportTransporterData" />

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/Completed.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/Completed.java
@@ -1,0 +1,80 @@
+package com.kkfc.milkbuddy;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.Toast;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class Completed extends AppCompatActivity {
+
+    DatabaseHelper db;
+    private Button resetButton;
+    AlertDialog.Builder builder;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_completed);
+
+        db = new DatabaseHelper(this);
+
+        resetButton = findViewById(R.id.button1);
+        builder = new AlertDialog.Builder(this);
+
+        resetButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                // This ends the cycle so we want to reset the app and redirect to homepage
+
+                builder.setMessage("Are you sure you want to reset Milk Buddy? You will not be able to export your data again once you reset the app.")
+                        .setCancelable(false)
+                        .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                Toast.makeText(getApplicationContext(),"Resetting the application",
+                                        Toast.LENGTH_SHORT).show();
+                                db.resetTables();
+                                // Redirect to import transporters page
+                                goToImportTransporters();
+                            }
+                        })
+                        .setNegativeButton("No", new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int id) {
+                                //  Action for 'NO' Button
+                                dialog.cancel();
+                                Toast.makeText(getApplicationContext(),"Cancelling application reset",
+                                        Toast.LENGTH_SHORT).show();
+                            }
+                        });
+                //Creating dialog box
+                AlertDialog alert = builder.create();
+                //Setting the title manually
+                alert.setTitle("Milk Buddy");
+                alert.show();
+            }
+        });
+
+
+    }
+
+    private void goToImportTransporters() {
+        Intent intent = new Intent(this, ImportTransporters.class);
+        startActivity(intent);
+    }
+
+    @Override
+    public void onBackPressed() {
+        // Allow a user to go back to the ExportPlantData page so that they can export again
+        // if they so choose
+        Intent intent = new Intent(this, ExportPlantData.class);
+        startActivity(intent);
+    }
+}

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/Completed.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/Completed.java
@@ -3,8 +3,10 @@ package com.kkfc.milkbuddy;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -42,6 +44,7 @@ public class Completed extends AppCompatActivity {
                                 Toast.makeText(getApplicationContext(),"Resetting the application",
                                         Toast.LENGTH_SHORT).show();
                                 db.resetTables();
+                                clearState();
                                 // Redirect to import transporters page
                                 goToImportTransporters();
                             }
@@ -63,6 +66,13 @@ public class Completed extends AppCompatActivity {
         });
 
 
+    }
+
+    // Clear state of farmer search page (checkboxes, search bar, dropdown)
+    private void clearState() {
+        SharedPreferences states = getSharedPreferences("states", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = states.edit();
+        editor.clear().commit();
     }
 
     private void goToImportTransporters() {

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
@@ -310,6 +310,9 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     // Save logged-in transporter data. Use -1 as the transporter ID
     public void insertLoggedInGuestTransporter(String name, String phoneNumber) {
         SQLiteDatabase db = this.getWritableDatabase();
+        // Delete existing entry from the table. The table will only be non-empty if the transporter
+        // goes back from the container selection page and chooses a different transporter
+        db.execSQL("DELETE FROM "+ TABLE_LOGGED_IN_TRANSPORTER);
         String insertStatement = "INSERT INTO " + TABLE_LOGGED_IN_TRANSPORTER + " VALUES(-1, '" +
                 name + "', '" + phoneNumber + "');";
         db.execSQL(insertStatement);

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
@@ -299,6 +299,9 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     // Save logged-in transporter data. This function is used for regular transporters (not guest)
     public void insertLoggedInTransporter(int id, String name, String phoneNumber) {
         SQLiteDatabase db = this.getWritableDatabase();
+        // Delete existing entry from the table. The table will only be non-empty if the transporter
+        // goes back from the container selection page and chooses a different transporter
+        db.execSQL("DELETE FROM "+ TABLE_LOGGED_IN_TRANSPORTER);
         String insertStatement = "INSERT INTO " + TABLE_LOGGED_IN_TRANSPORTER + " VALUES(" +
                 id + ", '" + name + "', '" + phoneNumber + "');";
         db.execSQL(insertStatement);

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
@@ -2,6 +2,7 @@ package com.kkfc.milkbuddy;
 
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
@@ -318,7 +318,16 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     // Save farmer collection data.
     public void insertFarmerCollection(int fId, int tId,int cId, double quantityL, String sniffTest, String alcoholTest, String densityTest, String wordComment, String createDate, String createTime) {
         SQLiteDatabase db = this.getWritableDatabase();
-        String insertStatement = "INSERT INTO " + TABLE_TRANSPORTER_DATA + " ( "+ TRANSPORTER_DATA_FARMER_ID + ", " + TRANSPORTER_DATA_TRANSPORTER_ID + ", " + TRANSPORTER_DATA_CONTAINER_ID + ", " + TRANSPORTER_DATA_QUANTITY_COLLECTED + ", " + TRANSPORTER_DATA_QUALITY_TEST_SMELL + ", " + TRANSPORTER_DATA_QUALITY_TEST_ALCOHOL + ", " + TRANSPORTER_DATA_QUALITY_TEST_DENSITY + ", " + TRANSPORTER_DATA_COMMENT + ", " + TRANSPORTER_DATA_CREATE_DATE + ", " + TRANSPORTER_DATA_CREATE_TIME + " ) " + "VALUES ('" + fId + "', '" + tId + "', '" + cId + "', '" + quantityL + "', '" + sniffTest + "', '" + alcoholTest + "', '" + densityTest + "', '" + wordComment + "', '" + createDate + "', '" + createTime +"');";
+        String insertStatement = "INSERT INTO " + TABLE_TRANSPORTER_DATA + " ( "+
+                TRANSPORTER_DATA_FARMER_ID + ", " + TRANSPORTER_DATA_TRANSPORTER_ID + ", " +
+                TRANSPORTER_DATA_CONTAINER_ID + ", " + TRANSPORTER_DATA_QUANTITY_COLLECTED + ", " +
+                TRANSPORTER_DATA_QUALITY_TEST_SMELL + ", " + TRANSPORTER_DATA_QUALITY_TEST_ALCOHOL + ", " +
+                TRANSPORTER_DATA_QUALITY_TEST_DENSITY + ", " + TRANSPORTER_DATA_COMMENT + ", " +
+                TRANSPORTER_DATA_CREATE_DATE + ", " + TRANSPORTER_DATA_CREATE_TIME + " ) " +
+                "VALUES ('" + fId + "', '" + tId + "', '" + cId + "', '" + quantityL + "', '" +
+                sniffTest + "', '" + alcoholTest + "', '" + densityTest + "', '" +
+                wordComment.replace("'", "''") + "', '" +
+                createDate + "', '" + createTime +"');";
         db.execSQL(insertStatement);
     }
 

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportPlantData.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportPlantData.java
@@ -75,10 +75,7 @@ public class ExportPlantData extends AppCompatActivity {
 
                     writer.close();
 
-                    // This ends the cycle so we want to reset the app and redirect to homepage
-                    // TODO maybe add pop-up here to let the receiver know they're all done!
-                    db.resetTables();
-                    Intent intent = new Intent(this, ImportTransporters.class);
+                    Intent intent = new Intent(this, Completed.class);
                     startActivity(intent);
                 } catch (IOException e) {
                     e.printStackTrace();
@@ -96,6 +93,9 @@ public class ExportPlantData extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // TODO
+        // Allow a user to go back to the ExportTransporterData page so that they can export again
+        // if they so choose
+        Intent intent = new Intent(this, ExportTransporterData.class);
+        startActivity(intent);
     }
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportTransporterData.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportTransporterData.java
@@ -96,7 +96,7 @@ public class ExportTransporterData extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // TODO
+        // This page is automatically navigated to once all milk containers have been
     }
 
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportTransporterData.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportTransporterData.java
@@ -96,7 +96,8 @@ public class ExportTransporterData extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // This page is automatically navigated to once all milk containers have been
+        // This page is automatically navigated to once all milk containers have been received.
+        // We do not want to allow going back to the receiver homepage once this has happened
     }
 
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportTransporterData.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportTransporterData.java
@@ -98,6 +98,7 @@ public class ExportTransporterData extends AppCompatActivity {
     public void onBackPressed() {
         // This page is automatically navigated to once all milk containers have been received.
         // We do not want to allow going back to the receiver homepage once this has happened
+        // (the receiver homepage would just redirect us here anyway since all containers are collected)
     }
 
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerCollection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerCollection.java
@@ -100,30 +100,8 @@ public class FarmerCollection extends AppCompatActivity {
         cancelCollection.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                builder.setMessage("All unsaved data will be lost. Are you sure you want to proceed?")
-                        .setCancelable(false)
-                        .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
-                                Toast.makeText(getApplicationContext(),"Collection Canceled",
-                                        Toast.LENGTH_SHORT).show();
-                                returnToFarmerSearch();
-
-
-                            }
-                        })
-                        .setNegativeButton("No", new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
-                                //  Action for 'NO' Button
-                                dialog.cancel();
-                                Toast.makeText(getApplicationContext(),"Cancel Aborted",
-                                        Toast.LENGTH_SHORT).show();
-                            }
-                        });
-                //Creating dialog box
-                AlertDialog alert = builder.create();
-                //Setting the title manually
-                alert.setTitle("Milk Buddy");
-                alert.show();
+                // Clicking the cancel button should do the same thing as clicking the back button
+                onBackPressed();
             }
         });
 
@@ -227,6 +205,29 @@ public class FarmerCollection extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        returnToFarmerSearch();
+        builder.setMessage("All unsaved data will be lost. Are you sure you want to proceed?")
+                .setCancelable(false)
+                .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        Toast.makeText(getApplicationContext(),"Collection Canceled",
+                                Toast.LENGTH_SHORT).show();
+                        returnToFarmerSearch();
+
+
+                    }
+                })
+                .setNegativeButton("No", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        //  Action for 'NO' Button
+                        dialog.cancel();
+                        Toast.makeText(getApplicationContext(),"Cancel Aborted",
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
+        //Creating dialog box
+        AlertDialog alert = builder.create();
+        //Setting the title manually
+        alert.setTitle("Milk Buddy");
+        alert.show();
     }
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerSearch.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerSearch.java
@@ -266,7 +266,9 @@ public class FarmerSearch extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // TODO
+        // We intentionally do not allow the user to go back from this page. Once the transporter has
+        // finished the set-up phase (importing, logging-in, and choosing containers) they may not
+        // go back to it unless they reset the app. 
     }
 
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerSearch.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerSearch.java
@@ -268,7 +268,7 @@ public class FarmerSearch extends AppCompatActivity {
     public void onBackPressed() {
         // We intentionally do not allow the user to go back from this page. Once the transporter has
         // finished the set-up phase (importing, logging-in, and choosing containers) they may not
-        // go back to it unless they reset the app. 
+        // go back to it unless they reset the app.
     }
 
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerSearch.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerSearch.java
@@ -120,16 +120,13 @@ public class FarmerSearch extends AppCompatActivity {
         transportersSpinnerView = findViewById(R.id.Spinner1);
         transportersSpinnerView.setAdapter(transporterCursorAdapter);
 
-        // Get dropdown selection from before (if applicable)
-        selectedDropdownRoute = states.getInt("selectedDropdownRoute", -1);
+        // Get prior dropdown selection (if applicable)
+        int selectedDropdownPosition = states.getInt("selectedDropdownPosition", -1);
 
         //Set dropdown selection
         // TODO
-        if(selectedDropdownRoute==-1){
-            transportersSpinnerView.setSelection(0);
-        } else {
-            transportersSpinnerView.setSelection(selectedDropdownRoute);
-        }
+
+        transportersSpinnerView.setSelection(selectedDropdownPosition);
 
 
         transportersSpinnerView.setOnItemSelectedListener(new OnItemSelectedListener() {
@@ -297,7 +294,7 @@ public class FarmerSearch extends AppCompatActivity {
         editor.putBoolean("activeCheckbox", active_checkbox.isChecked());
         editor.putBoolean("collectedCheckbox", collected_checkbox.isChecked());
         editor.putString("searchBarQuery", searchBarQuery);
-        editor.putInt("selectedDropdownRoute", selectedDropdownRoute);
+        editor.putInt("selectedDropdownPosition", transportersSpinnerView.getSelectedItemPosition());
         editor.commit();
     }
 

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/GuestTransporter.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/GuestTransporter.java
@@ -27,7 +27,8 @@ public class GuestTransporter extends AppCompatActivity {
         cancelGuestTransporter.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                goBackTransporterLogin();
+                // Cancel button should do the same thing as back button
+                onBackPressed();
             }
         });
 
@@ -61,7 +62,7 @@ public class GuestTransporter extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // TODO
+        goBackTransporterLogin();
     }
 
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ImportTransporters.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ImportTransporters.java
@@ -145,7 +145,7 @@ public class ImportTransporters extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // TODO
+        // This is the first page of the app. Pressing the back button should do nothing.
     }
 
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ImportTransporters.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ImportTransporters.java
@@ -34,7 +34,6 @@ public class ImportTransporters extends AppCompatActivity {
 
         db = new DatabaseHelper(this);
 
-        // TODO: put this in a separate java class? add this in other pages too??
         // CHECK STATE OF APP
         // Is there a logged-in transporter?
         Cursor loggedInTransporter = db.fetchLoggedInTransporter();

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
@@ -2,6 +2,7 @@ package com.kkfc.milkbuddy;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.Intent;
 import android.os.Bundle;
 
 public class ReceiverCollection extends AppCompatActivity {
@@ -10,5 +11,12 @@ public class ReceiverCollection extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_receiver_collection);
+    }
+
+    @Override
+    public void onBackPressed() {
+        // TODO add warning before going back. Also use this function for the cancel button
+        Intent intent = new Intent(this, ReceiverHome.class);
+        startActivity(intent);
     }
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
@@ -15,7 +15,7 @@ public class ReceiverCollection extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // TODO add warning before going back. Also use this function for the cancel button
+        // TODO add warning/pop-up before going back. Also use this function for the cancel button
         Intent intent = new Intent(this, ReceiverHome.class);
         startActivity(intent);
     }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
@@ -58,6 +58,7 @@ public class ReceiverHome extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // TODO
+        // Once a receiver has logged in, the farmer search/collection page and receiver login pages
+        // are no longer accessible so we disable the back button (i.e. it does nothing).
     }
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
@@ -26,6 +26,8 @@ public class ReceiverHome extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_receiver_home);
 
+        // TODO: Automatically redirect to export page if all containers are received
+
         NAME = (TextView) findViewById(R.id.transporterName);
 
         db = new DatabaseHelper(this);

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverLogin.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverLogin.java
@@ -11,6 +11,7 @@ public class ReceiverLogin extends AppCompatActivity {
 
     DatabaseHelper db;
     private Button loginReceiver;
+    private Button cancelButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -18,6 +19,15 @@ public class ReceiverLogin extends AppCompatActivity {
         setContentView(R.layout.activity_receiver_login);
 
         db = new DatabaseHelper(this);
+
+        cancelButton = findViewById(R.id.Button01);
+        cancelButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                // Pressing the cancel button does the same thing as pressing the back button
+                onBackPressed();
+            }
+        });
 
         loginReceiver = findViewById(R.id.Button02);
         loginReceiver.setOnClickListener(new View.OnClickListener() {
@@ -35,6 +45,9 @@ public class ReceiverLogin extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // TODO
+        // We allow the user to go back to farmer search/collection as long as no receiver is
+        // logged-in yet. Once a receiver logs in, farmer search/collection will no longer be accessible
+        Intent intent = new Intent(this, FarmerSearch.class);
+        startActivity(intent);
     }
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverLogin.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverLogin.java
@@ -33,6 +33,8 @@ public class ReceiverLogin extends AppCompatActivity {
         loginReceiver.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+
+                // TODO show popup if empty fields and disallow moving forward
                 goToReceiverHomepage();
             }
         });

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/TransporterContainerSelection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/TransporterContainerSelection.java
@@ -314,6 +314,13 @@ public class TransporterContainerSelection extends AppCompatActivity {
         // transporter table and reenter the new transporter selected
         Intent intent = new Intent(this, TransporterLogin.class);
         startActivity(intent);
+        // When the user clicks the back button, they are navigated back to the transporter login.
+        // Since they will need to re-log-in to proceed, we can safely delete the prior selection
+        // Deleting this is necessary because if we leave the prior entry in the table and the user
+        // keeps clicking the back button until they reach the import transporters page (first page
+        // of app), the state check will go through and re-direct the user to the container page since
+        // the state of the app will technically be logged-in transporter with no container selection
+        db.deleteLoggedInTransporter();
     }
 
 

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/TransporterContainerSelection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/TransporterContainerSelection.java
@@ -309,7 +309,11 @@ public class TransporterContainerSelection extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // TODO
+        // We will allow the user to go back to the transporter login page and select a different
+        // transporter. When that happens, we will simply erase the existing data from the logged-in
+        // transporter table and reenter the new transporter selected
+        Intent intent = new Intent(this, TransporterLogin.class);
+        startActivity(intent);
     }
 
 

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/TransporterLogin.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/TransporterLogin.java
@@ -81,6 +81,7 @@ public class TransporterLogin extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        // TODO
+        Intent intent = new Intent(this, ImportFarmers.class);
+        startActivity(intent);
     }
 }

--- a/MilkBuddy/app/src/main/res/layout/activity_completed.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_completed.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".Completed">
+
+    <TableLayout
+        android:id="@+id/tableLayout"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:stretchColumns="*"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TableRow
+            android:id="@+id/first_row"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/textView1"
+                android:layout_width="match_parent"
+                android:layout_height="fill_parent"
+                android:layout_marginTop="10dp"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:text="You're all done! Reset the app to start a new session. "
+                android:textSize="25sp" />
+        </TableRow>
+
+        <TableRow
+            android:id="@+id/second_row"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1">
+
+            <Button
+                android:id="@+id/button1"
+                android:layout_width="match_parent"
+                android:layout_height="fill_parent"
+                android:layout_margin="10dp"
+                android:layout_weight="1"
+                android:text="Reset"
+                android:textSize="25sp" />
+        </TableRow>
+
+    </TableLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
All back buttons are now done. To test this, please try to use every back button and experiment with the sequence of clicks (i.e. try to break the app!). I have added comments in the code to clearly explain all functionality so feel free to check that out. Every single page (except DatabaseHelper) has a function called `onBackPressed` which is where the functionality for the back button is.
I have also added a completion page for the end of the flow. The main motivation for doing this (rather than just sending the user back to the import transporters page after exporting) is so that the user has the ability to export again in case something happens. It also provides feedback for the user so that they understand they're done! To test this, please go through the whole app flow. Make sure to try using the reset button on the completion page to start a new session (i.e. start over). 
