### PR TITLE
Export transporter collection data to CSV

### DIFF
--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
@@ -246,14 +246,20 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     // Fetch transporter data table
     public Cursor fetchTransporterDataToExport() {
         SQLiteDatabase db = this.getWritableDatabase();
-        String query = "SELECT * FROM " + TABLE_TRANSPORTER_DATA + " AS data INNER JOIN " + "(SELECT " +
-                FARMER_ID + " AS farmer_id, " + FARMER_NAME + " AS farmer_name, " + FARMER_PHONE_NUMBER +
+        String query = "SELECT " + TRANSPORTER_DATA_PICK_UP_NUMBER + ", " + TRANSPORTER_DATA_CONTAINER_ID +
+                ", " + TRANSPORTER_DATA_QUANTITY_COLLECTED + ", " + TRANSPORTER_DATA_QUALITY_TEST_SMELL +
+                ", " + TRANSPORTER_DATA_QUALITY_TEST_ALCOHOL + ", " + TRANSPORTER_DATA_QUALITY_TEST_DENSITY +
+                ", " + TRANSPORTER_DATA_COMMENT + ", " + TRANSPORTER_DATA_CREATE_DATE + ", " +
+                TRANSPORTER_DATA_CREATE_TIME + ", " + TRANSPORTER_DATA_FARMER_ID + ", farmer_name, farmer_phone_number, " +
+                TRANSPORTER_DATA_TRANSPORTER_ID + ", transporter_name, transporter_phone_number FROM " +
+                TABLE_TRANSPORTER_DATA + " AS data INNER JOIN " + "(SELECT " +
+                FARMER_ID + " AS farmer_id_2, " + FARMER_NAME + " AS farmer_name, " + FARMER_PHONE_NUMBER +
                 " AS farmer_phone_number FROM " + TABLE_FARMER + ") AS farmer ON data." +
-                TRANSPORTER_DATA_FARMER_ID + "=farmer.farmer_id INNER JOIN (SELECT " + LOGGED_IN_TRANSPORTER_ID +
-                " AS transporter_id, " + LOGGED_IN_TRANSPORTER_NAME + " AS transporter_name, " +
+                TRANSPORTER_DATA_FARMER_ID + "=farmer.farmer_id_2 INNER JOIN (SELECT " + LOGGED_IN_TRANSPORTER_ID +
+                " AS transporter_id_2, " + LOGGED_IN_TRANSPORTER_NAME + " AS transporter_name, " +
                 LOGGED_IN_TRANSPORTER_PHONE_NUMBER + " AS transporter_phone_number FROM " +
                 TABLE_LOGGED_IN_TRANSPORTER + ") AS transporter ON data." + TRANSPORTER_DATA_TRANSPORTER_ID +
-                "=transporter.transporter_id";
+                "=transporter.transporter_id_2";
         Log.i("query", query);
         Cursor cursor = db.rawQuery(query, null);
         return cursor;

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/DatabaseHelper.java
@@ -244,6 +244,22 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     // Fetch transporter data table
+    public Cursor fetchTransporterDataToExport() {
+        SQLiteDatabase db = this.getWritableDatabase();
+        String query = "SELECT * FROM " + TABLE_TRANSPORTER_DATA + " AS data INNER JOIN " + "(SELECT " +
+                FARMER_ID + " AS farmer_id, " + FARMER_NAME + " AS farmer_name, " + FARMER_PHONE_NUMBER +
+                " AS farmer_phone_number FROM " + TABLE_FARMER + ") AS farmer ON data." +
+                TRANSPORTER_DATA_FARMER_ID + "=farmer.farmer_id INNER JOIN (SELECT " + LOGGED_IN_TRANSPORTER_ID +
+                " AS transporter_id, " + LOGGED_IN_TRANSPORTER_NAME + " AS transporter_name, " +
+                LOGGED_IN_TRANSPORTER_PHONE_NUMBER + " AS transporter_phone_number FROM " +
+                TABLE_LOGGED_IN_TRANSPORTER + ") AS transporter ON data." + TRANSPORTER_DATA_TRANSPORTER_ID +
+                "=transporter.transporter_id";
+        Log.i("query", query);
+        Cursor cursor = db.rawQuery(query, null);
+        return cursor;
+    }
+
+    // Fetch transporter data table
     public Cursor fetchPlantData() {
         SQLiteDatabase db = this.getWritableDatabase();
         Cursor cursor = db.rawQuery("SELECT * FROM " + TABLE_PLANT_DATA, null);

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportTransporterData.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportTransporterData.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -67,18 +68,24 @@ public class ExportTransporterData extends AppCompatActivity {
                     if(cursor.getCount() == 0) {
                         Toast.makeText(this, "No data to export", Toast.LENGTH_LONG).show();
                     } else {
+                        // Write column names to file as a header
+                        String[] columnNamesArray = cursor.getColumnNames();
+                        String columnNamesString = TextUtils.join(",", columnNamesArray);
+                        writer.write(columnNamesString + "\n");
+
+                        // Write actual data to file
                         while(cursor.moveToNext()) {
-                            // 1 is the column for first name
-                            String blah = cursor.getString(1) + " " + cursor.getString(2);
-                            // TODO
-                            // write header
 
-                            writer.write("DO I WORK?, YES\n");
+                            String[] valuesArray = new String[cursor.getColumnCount()];
 
+                            for(int i=0; i < cursor.getColumnCount(); i ++ ) {
+                                valuesArray[i] = cursor.getString(i);
+                            }
+
+                            String valuesString = TextUtils.join(",", valuesArray);
+                            writer.write(valuesString + "\n");
                         }
                     }
-
-
                     
                     writer.close();
 

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportTransporterData.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ExportTransporterData.java
@@ -62,19 +62,23 @@ public class ExportTransporterData extends AppCompatActivity {
                     OutputStream outputStream = getContentResolver().openOutputStream(uri);
                     BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(outputStream));
 
-                    Cursor cursor = db.fetchTransporterData();
+                    Cursor cursor = db.fetchTransporterDataToExport();
+
                     if(cursor.getCount() == 0) {
                         Toast.makeText(this, "No data to export", Toast.LENGTH_LONG).show();
                     } else {
                         while(cursor.moveToNext()) {
                             // 1 is the column for first name
-                             String blah = cursor.getString(1) + " " + cursor.getString(2);
+                            String blah = cursor.getString(1) + " " + cursor.getString(2);
+                            // TODO
+                            // write header
+
+                            writer.write("DO I WORK?, YES\n");
+
                         }
                     }
 
-                    // TODO
 
-                    writer.write("DO I WORK?, YES");
                     
                     writer.close();
 


### PR DESCRIPTION
I have finished the export functionality for transporter data. For testing, please collect from a bunch of farmers with varying sizes, containers, quality test values, etc. Then click "drop off" and login as a receiver. Then export the transporter data. The csv file will save to your emulator but you won't be able to open it on your emulator. To view the file, go to your emulator's file explorer. Look under 'mnt/sdcard/Download' and you should see your exported file. Right click on the file and save to your computer (choose whatever directory you want). Then you can open up the file in Excel to see how it looks. Your output should look something like this:
<img width="1114" alt="Screen Shot 2020-03-04 at 10 23 25 PM" src="https://user-images.githubusercontent.com/41701024/75944888-cc91be00-5e66-11ea-908b-2e8be2783b07.png">
Please check to make sure everything has been recorded correctly. 