### PR TITLE
Display receiver name on the receiver collection page + cancel button pop-up on receiver collection page

### DIFF
--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
@@ -1,22 +1,79 @@
 package com.kkfc.milkbuddy;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.Toast;
+
 
 public class ReceiverCollection extends AppCompatActivity {
+
+    AlertDialog.Builder builder;
+    private Button cancelCollection;
+
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_receiver_collection);
+
+        // Cancel Collection Process
+        cancelCollection = findViewById(R.id.Button01);
+        builder = new AlertDialog.Builder(this);
+        cancelCollection.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                // Clicking the cancel button should do the same thing as clicking the back button
+                onBackPressed();
+            }
+        });
     }
+
+    private void returnToReceiverHome() {
+        Intent intent = new Intent(this, ReceiverHome.class);
+        startActivity(intent);
+    }
+
+  //  @Override
+    //public void onBackPressed() {
+        // TODO add warning/pop-up before going back. Also use this function for the cancel button
+
+      //  Intent intent = new Intent(this, ReceiverHome.class);
+        //startActivity(intent);
+   // }
+
 
     @Override
     public void onBackPressed() {
-        // TODO add warning/pop-up before going back. Also use this function for the cancel button
-        Intent intent = new Intent(this, ReceiverHome.class);
-        startActivity(intent);
+        builder.setMessage("All unsaved data will be lost. Are you sure you want to proceed?")
+                .setCancelable(false)
+                .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        Toast.makeText(getApplicationContext(),"Collection Canceled",
+                                Toast.LENGTH_SHORT).show();
+                        returnToReceiverHome();
+
+
+                    }
+                })
+                .setNegativeButton("No", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        //  Action for 'NO' Button
+                        dialog.cancel();
+                        Toast.makeText(getApplicationContext(),"Cancel Aborted",
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
+        //Creating dialog box
+        AlertDialog alert = builder.create();
+        //Setting the title manually
+        alert.setTitle("Milk Buddy");
+        alert.show();
     }
 }

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
@@ -40,14 +40,6 @@ public class ReceiverCollection extends AppCompatActivity {
         startActivity(intent);
     }
 
-  //  @Override
-    //public void onBackPressed() {
-        // TODO add warning/pop-up before going back. Also use this function for the cancel button
-
-      //  Intent intent = new Intent(this, ReceiverHome.class);
-        //startActivity(intent);
-   // }
-
 
     @Override
     public void onBackPressed() {

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
@@ -16,6 +16,7 @@ public class ReceiverHome extends AppCompatActivity {
 
     DatabaseHelper db;
     private TextView NAME;
+    private TextView receiverName;
     private ListView containerListView;
     private Button exportButton;
     SimpleCursorAdapter containerCursorAdapter;
@@ -29,6 +30,7 @@ public class ReceiverHome extends AppCompatActivity {
         // TODO: Automatically redirect to export page if all containers are received
 
         NAME = (TextView) findViewById(R.id.transporterName);
+        receiverName = (TextView) findViewById(R.id.receiverName);
 
         db = new DatabaseHelper(this);
 
@@ -40,6 +42,17 @@ public class ReceiverHome extends AppCompatActivity {
         Log.i("logged in", loggedInTransporter);
         NAME= (TextView)findViewById(R.id.transporterName);
         NAME.setText("These are " + loggedInTransporter + "'s containers");
+
+        //Fetch the loggedInReciever to show on the UI
+        Cursor c = db.fetchLoggedInReceiver();
+        //only one row in the table so use the first row
+        c.moveToFirst();
+        String loggedInReceiver = c.getString(c.getColumnIndex(db.RECEIVER_NAME));
+        Log.i("logged in", loggedInReceiver);
+        receiverName = (TextView)findViewById(R.id.receiverName);
+        receiverName.setText("Hello " + loggedInReceiver + "!");
+
+
 
         exportButton = findViewById(R.id.button1);
         exportButton.setOnClickListener(new View.OnClickListener() {

--- a/MilkBuddy/app/src/main/res/layout/activity_receiver_home.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_receiver_home.xml
@@ -26,11 +26,11 @@
                 android:orientation="horizontal">
 
                 <TextView
-                    android:id="@+id/textView18"
+                    android:id="@+id/receiverName"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_weight="1"
-                    android:text="Hello Reciever A!"
+                    android:text="TextView"
                     android:textColor="#0A0808"
                     android:textSize="24sp" />
             </LinearLayout>


### PR DESCRIPTION
Displayed the logged in receivers name on the receiver collection page. 

**Testing instruction** 
1. Login in as a transporter 
2. Click on the drop-off button on the farmer search page
3. Login as a receiver (try and login as a different person from who you chose as the transporter)
You should see the receivers name you logged in as on the receiver homepage 

Created pop-up for the cancel button and back pressed button on the receiver collection page which re-directs the user back to the receiver homepage 

**Testing Instruction** 
1. Click on a container on the receiver homepage 
2. Click on the cancel button on the receiver collection page. A pop-up appears. Clicking "yes" takes you back to the receiver homepage, clicking "No" keeps you on the receiver collection page
3. Clicking on the back button should have the same functionality as step 2


