### PR TITLE
Automatically redirect to export pages + removed export button

### DIFF
--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
@@ -46,7 +46,6 @@ public class ReceiverHome extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_receiver_home);
 
-        // TODO: Automatically redirect to export page if all containers are received
 
         NAME = (TextView) findViewById(R.id.transporterName);
         receiverName = (TextView) findViewById(R.id.receiverName);
@@ -73,14 +72,14 @@ public class ReceiverHome extends AppCompatActivity {
 
 
 
-        exportButton = findViewById(R.id.button1);
+       /* exportButton = findViewById(R.id.button1);
         exportButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 exportData();
             }
 
-        });
+        });*/
 
 
         // List transporters
@@ -88,7 +87,7 @@ public class ReceiverHome extends AppCompatActivity {
         containerListView = findViewById(R.id.list_view);
 
         if(containerCursor.getCount() == 0) {
-            Toast.makeText(this, "No data to show", Toast.LENGTH_LONG).show();
+            exportData();
         } else {
             containerCursorAdapter = new SimpleCursorAdapter(this, R.layout.container_list_entry, containerCursor, containerColumns, containerTo, 0);
             containerListView.setAdapter(containerCursorAdapter);

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
@@ -27,18 +27,13 @@ public class ReceiverHome extends AppCompatActivity {
     // THE DESIRED COLUMNS TO BE BOUND
     String[] containerColumns = new String[]{
             "container_info"
-            //db.CONTAINER_ID,
-            //db.CONTAINER_SIZE
     };
 
     // THE XML DEFINED VIEWS WHICH THE DATA WILL BE BOUND TO
    int[] containerTo = new int[]{
             R.id.container_id,
-            //R.id.container_size
     };
 
-    //String [] containerColumns = new String[]{"container_dropdown"};
-    //int[] containerTo =new int[]{android.R.id.list};
 
 
     @Override
@@ -69,17 +64,6 @@ public class ReceiverHome extends AppCompatActivity {
         Log.i("logged in", loggedInReceiver);
         receiverName = (TextView)findViewById(R.id.receiverName);
         receiverName.setText("Hello " + loggedInReceiver + "!");
-
-
-
-       /* exportButton = findViewById(R.id.button1);
-        exportButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                exportData();
-            }
-
-        });*/
 
 
         // List transporters

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
@@ -66,7 +66,6 @@ public class ReceiverHome extends AppCompatActivity {
         receiverName.setText("Hello " + loggedInReceiver + "!");
 
 
-        // List transporters
         Cursor containerCursor = db.fetchConcatContainerForReceiver();
         containerListView = findViewById(R.id.list_view);
 

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverHome.java
@@ -69,12 +69,12 @@ public class ReceiverHome extends AppCompatActivity {
         Cursor containerCursor = db.fetchConcatContainerForReceiver();
         containerListView = findViewById(R.id.list_view);
 
+        // If there are no containers left to display on the homepage, redirect to export page
         if(containerCursor.getCount() == 0) {
             exportData();
         } else {
             containerCursorAdapter = new SimpleCursorAdapter(this, R.layout.container_list_entry, containerCursor, containerColumns, containerTo, 0);
             containerListView.setAdapter(containerCursorAdapter);
-
         }
 
 

--- a/MilkBuddy/app/src/main/res/layout/activity_receiver_home.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_receiver_home.xml
@@ -6,76 +6,63 @@
     android:layout_height="match_parent"
     tools:context=".ReceiverHome">
 
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    <LinearLayout
+        android:id="@+id/linearLayout2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginRight="16dp"
-            android:layout_marginBottom="16dp"
-            android:orientation="vertical">
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
 
-            <LinearLayout
+            <TextView
+                android:id="@+id/receiverName"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="horizontal">
+                android:layout_weight="1"
+                android:text="TextView"
+                android:textColor="#0A0808"
+                android:textSize="24sp" />
+        </LinearLayout>
 
-                <TextView
-                    android:id="@+id/receiverName"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:text="TextView"
-                    android:textColor="#0A0808"
-                    android:textSize="24sp" />
-            </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal"
+            android:paddingTop="10dp">
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal"
-                android:paddingTop="10dp">
-
-                <TextView
-                    android:id="@+id/transporterName"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="TextView"
-                    android:textSize="18sp" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="459dp"
-                android:orientation="horizontal">
-
-                <ListView
-                    android:id="@+id/list_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:dividerHeight="1dp"
-                    android:padding="10dp"></ListView>
-            </LinearLayout>
-
-            <LinearLayout
+            <TextView
+                android:id="@+id/transporterName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <Button
-                    android:id="@+id/button1"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="Export to CSV" />
-
-            </LinearLayout>
-
+                android:text="TextView"
+                android:textSize="18sp" />
         </LinearLayout>
-    </ScrollView>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="459dp"
+            android:orientation="horizontal">
+
+            <ListView
+                android:id="@+id/list_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:dividerHeight="1dp"
+                android:padding="10dp"></ListView>
+        </LinearLayout>
+
+    </LinearLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Automatically redirect to export pages once all containers are received + removed export button on the receiver homepage 

**Testing Instruction** 
1. Add containers 
2. Navigate to the receiver homepage
3. Receive all the containers you have selected 
Once you have received all containers as a receiver, you should be automatically re-directed to the export pages. If you have not receiver at least one container, you will be re-directed back to the receiver homepage 

The "Export to CSV" should no longer appear on the receiver homepage 

