### PR TITLE
Added a "fail" option to the density test on the farmer collection page

### DIFF
--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerCollection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerCollection.java
@@ -37,7 +37,7 @@ public class FarmerCollection extends AppCompatActivity {
     private TextView nameFarmer;
     private EditText quantity;
     private EditText comment;
-    private RadioButton sniffPass, sniffFail, sniffNa, alcoholPass, alcoholFail, alcoholNa,densityTwoSeven, densityTwoEight, densityTwoNine, densityThirty, densityThirtyOnePlus, densityNa ;
+    private RadioButton sniffPass, sniffFail, sniffNa, alcoholPass, alcoholFail, alcoholNa,densityTwoSeven, densityTwoEight, densityTwoNine, densityThirty, densityThirtyOnePlus, densityFail, densityNa ;
     private String sniffTest;
     private String alcoholTest;
     private String densityTest;
@@ -47,6 +47,7 @@ public class FarmerCollection extends AppCompatActivity {
     private Spinner containerSpinnerView;
     private RadioGroup radioSniffTestGroup;
     private RadioGroup radioAlcoholTestGroup;
+    private RadioGroup radioDensityTestGroup;
 
 
 
@@ -93,45 +94,36 @@ public class FarmerCollection extends AppCompatActivity {
             }
         });
 
-        // Greying out container dropdown when sniff or alcohol tests fail
-       radioSniffTestGroup = findViewById(R.id.radioGroup1);
-       radioSniffTestGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+
+
+        // Greying out container dropdown when sniff, alcohol, or density tests fail
+        radioSniffTestGroup = findViewById(R.id.radioGroup1);
+        radioSniffTestGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
            @Override
            public void onCheckedChanged(RadioGroup group, int checkedId) {
-
-               //Gathering collection data from sniff and alcohol tests
-               RadioButton sniffTestFail = findViewById(R.id.radioButton2);
-               RadioButton alcoholTestFail = findViewById(R.id.radioButton5);
-
-               if(sniffTestFail.isChecked() || alcoholTestFail.isChecked()){
-                   containerSpinnerView.setEnabled(false);
-                   containerSpinnerView.setClickable(false);
-               } else {
-                   containerSpinnerView.setEnabled(true);
-                   containerSpinnerView.setClickable(true);
-               }
+               enableOrDisableContainerDropdown();
            }
-       });
+        });
 
+        // Greying out container dropdown when sniff, alcohol, or density tests fail
         radioAlcoholTestGroup = findViewById(R.id.radioGroup2);
         radioAlcoholTestGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(RadioGroup group, int checkedId) {
-
-                //Gathering collection data from sniff and alcohol tests
-                RadioButton sniffTestFail = findViewById(R.id.radioButton2);
-                RadioButton alcoholTestFail = findViewById(R.id.radioButton5);
-
-                if(sniffTestFail.isChecked() || alcoholTestFail.isChecked()){
-                    containerSpinnerView.setEnabled(false);
-                    containerSpinnerView.setClickable(false);
-                } else {
-                    containerSpinnerView.setEnabled(true);
-                    containerSpinnerView.setClickable(true);
-                }
-
+                enableOrDisableContainerDropdown();
             }
         });
+
+        // Greying out container dropdown when sniff, alcohol, or density tests fail
+        radioDensityTestGroup = findViewById(R.id.radioGroup3);
+        radioDensityTestGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(RadioGroup group, int checkedId) {
+                enableOrDisableContainerDropdown();
+            }
+        });
+
+
 
         // Cancel Collection Process
         cancelCollection = findViewById(R.id.Button01);
@@ -185,7 +177,8 @@ public class FarmerCollection extends AppCompatActivity {
                 densityTwoNine = findViewById(R.id.radioButton9);
                 densityThirty = findViewById(R.id.radioButton10);
                 densityThirtyOnePlus = findViewById(R.id.radioButton11);
-                densityNa = findViewById(R.id.radioButton12);
+                densityFail = findViewById(R.id.radioButton12);
+                densityNa = findViewById(R.id.radioButton13);
                 if(densityTwoSeven.isChecked()){
                     densityTest = densityTwoSeven.getText().toString();
                 } else if(densityTwoEight.isChecked()){
@@ -196,6 +189,8 @@ public class FarmerCollection extends AppCompatActivity {
                     densityTest=densityThirty.getText().toString();
                 } else if(densityThirtyOnePlus.isChecked()){
                     densityTest=densityThirtyOnePlus.getText().toString();
+                } else if(densityFail.isChecked()){
+                    densityTest=densityFail.getText().toString();
                 } else if(densityNa.isChecked()){
                     densityTest=densityNa.getText().toString();
                 }
@@ -207,7 +202,7 @@ public class FarmerCollection extends AppCompatActivity {
                     quantity.setError("Please collect milk quantity, otherwise click 'Cancel'");
                 } else {
                     final Double quantityL = Double.parseDouble(quantityLitre);
-                    if(alcoholTest.equals("Fail")||sniffTest.equals("Fail")){
+                    if(alcoholTest.equals("Fail") || sniffTest.equals("Fail") || densityTest.equals("Fail") ){
                         // Recorded milk collection with failed tests
                         containerId = -1;
                         builder.setMessage("Are you sure you want to save farmer collection with failed test?")
@@ -296,6 +291,23 @@ public class FarmerCollection extends AppCompatActivity {
             }
         });
 
+    }
+
+    // Grey out container dropdown when there are any failing tests (since the milk will be rejected,
+    // it won't be added to any container
+    private void enableOrDisableContainerDropdown() {
+        //Gathering collection data from sniff and alcohol tests
+        RadioButton sniffTestFail = findViewById(R.id.radioButton2);
+        RadioButton alcoholTestFail = findViewById(R.id.radioButton5);
+        RadioButton densityTestFail = findViewById(R.id.radioButton12);
+
+        if(sniffTestFail.isChecked() || alcoholTestFail.isChecked() || densityTestFail.isChecked()){
+            containerSpinnerView.setEnabled(false);
+            containerSpinnerView.setClickable(false);
+        } else {
+            containerSpinnerView.setEnabled(true);
+            containerSpinnerView.setClickable(true);
+        }
     }
 
     private void returnToFarmerSearch() {

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerCollection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/FarmerCollection.java
@@ -309,7 +309,7 @@ public class FarmerCollection extends AppCompatActivity {
                 .setCancelable(false)
                 .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        Toast.makeText(getApplicationContext(),"Collection Canceled",
+                        Toast.makeText(getApplicationContext(),"Collection Cancelled",
                                 Toast.LENGTH_SHORT).show();
                         returnToFarmerSearch();
 

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
@@ -296,7 +296,7 @@ public class ReceiverCollection extends AppCompatActivity {
                 .setCancelable(false)
                 .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        Toast.makeText(getApplicationContext(),"Collection Canceled",
+                        Toast.makeText(getApplicationContext(),"Collection Cancelled",
                                 Toast.LENGTH_SHORT).show();
                         returnToReceiverHome();
 

--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/ReceiverCollection.java
@@ -210,7 +210,7 @@ public class ReceiverCollection extends AppCompatActivity {
                         } else {
                             // Check failing quantity tests
                             if (alcoholTest.equals("Fail") || sniffTest.equals("Fail")) {
-                                builder.setMessage("You have failed quality test(S). Are you sure you want to proceed?")
+                                builder.setMessage("You have failed quality test(s). Are you sure you want to proceed?")
                                         .setCancelable(false)
                                         .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
                                             public void onClick(DialogInterface dialog, int id) {

--- a/MilkBuddy/app/src/main/res/layout/activity_farmer_collection.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_farmer_collection.xml
@@ -194,6 +194,14 @@
                     android:id="@+id/radioButton12"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:text="Fail"
+                    android:checked="false"
+                    android:textSize="20sp"/>
+
+                <RadioButton
+                    android:id="@+id/radioButton13"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:text="N/A"
                     android:checked="true"
                     android:textSize="20sp"/>

--- a/MilkBuddy/app/src/main/res/layout/activity_transporter_container_selection.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_transporter_container_selection.xml
@@ -7,13 +7,18 @@
     tools:context=".TransporterContainerSelection">
 
     <ScrollView
+        android:id="@+id/scrollView2"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fillViewport="true">>
+        android:layout_height="wrap_content"
+        android:fillViewport="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">>
+
         <LinearLayout
             android:id="@+id/linearLayout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_margin="16dp"
             android:layout_marginStart="16dp"
             android:layout_marginLeft="16dp"
@@ -394,12 +399,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="5dp"
-                    android:text="Next"
-             />
+                    android:text="Next" />
 
             </LinearLayout>
-
-
         </LinearLayout>
     </ScrollView>
 


### PR DESCRIPTION
The farmer collection page now has a fail radio button for the density test. To test this, please collect milk from various farmers using various density options (make sure to use the fail option for at least one). Make sure when the "fail" radio button is selected for the density test, the container dropdown is greyed out. When the density test is failed, the quantity entered should not be subtracted from any of the containers. Please make sure of this.
Please export the collection data to CSV and make sure everything looks right (make sure the failed density test results in a container ID of -1, etc.)