### PR TITLE
Add check for empty fields on guest transporter login

### DIFF
--- a/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/GuestTransporter.java
+++ b/MilkBuddy/app/src/main/java/com/kkfc/milkbuddy/GuestTransporter.java
@@ -39,11 +39,18 @@ public class GuestTransporter extends AppCompatActivity {
                 // Save guest transporter info to database
                 guestTransporterName = findViewById(R.id.editText1);
                 guestTransporterPhoneNumber = findViewById(R.id.editText2);
-                db.insertLoggedInGuestTransporter(
-                        guestTransporterName.getText().toString(),
-                        guestTransporterPhoneNumber.getText().toString()
-                );
-                goToTransporterHomepage();
+
+                if(guestTransporterName.getText().toString().length()==0 ){
+                    guestTransporterName.setError("Please input a name");
+                } else if (guestTransporterPhoneNumber.getText().toString().length()==0){
+                    guestTransporterPhoneNumber.setError("Please input a phone number");
+                }else {
+                    db.insertLoggedInGuestTransporter(
+                            guestTransporterName.getText().toString(),
+                            guestTransporterPhoneNumber.getText().toString()
+                    );
+                    goToTransporterHomepage();
+                }
             }
         });
 


### PR DESCRIPTION
To Test Go to Guest transporter login and click login without a name or phone number. You should get a warning and not be allowed to login until you add a name and phone number 