### PR TITLE
Increased space on the farmer search page

### DIFF
--- a/MilkBuddy/app/src/main/res/layout/activity_farmer_search.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_farmer_search.xml
@@ -3,6 +3,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">
 
        <LinearLayout
@@ -32,36 +33,18 @@
 
        </LinearLayout>
 
-    <TextView
-        android:id="@+id/textView1"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:layout_marginLeft="20dp"
-        android:layout_marginRight="20dp"
-        android:layout_marginTop="10dp"
-        android:layout_marginBottom="10dp"
-        android:text="Search for a Farmer"
-        android:textColor="#000000"
-        android:textSize="20sp"/>
-
     <SearchView
         android:id="@+id/farmerSearchView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"/>
-
-    <TextView
-        android:id="@+id/textView8"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginLeft="20dp"
-        android:layout_marginRight="20dp"
-        android:layout_marginTop="10dp"
-        android:text="Filter Route by Transporter:"
-        android:textSize="18sp"
-        android:textColor="#000000"/>
+        android:layout_marginRight="10dp"
+        android:queryHint="Search for a farmer"
+        app:queryHint="Search for a farmer"
+        app:defaultQueryHint="Search for a farmer"
+        android:iconifiedByDefault="false"
+        app:iconifiedByDefault="false"
+        />
 
     <Spinner
         android:id="@+id/Spinner1"


### PR DESCRIPTION
Navigate to the farmer search page. The title "Search for a farmer" on top of the search bar has been removed. The title "Filter by a transporter" above the routes drop-down has been removed. I added a placeholder in the search bar. You should see a "Search for a farmer" placeholder in the search bar

Check to make sure the Search bar works as intended

![image](https://user-images.githubusercontent.com/20653189/76689797-fe95e380-660f-11ea-9c3e-21cffc674723.png)
