### PR TITLE
Fixed UI for Receiver Collection page and limited number of characters for quantity inputs

### DIFF
--- a/MilkBuddy/app/src/main/res/layout/activity_farmer_collection.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_farmer_collection.xml
@@ -236,6 +236,7 @@
                 android:layout_height="wrap_content"
                 android:ems="10"
                 android:inputType="numberDecimal"
+                android:maxLength="5"
                 android:imeOptions="actionDone"/>
 
         </TableRow>

--- a/MilkBuddy/app/src/main/res/layout/activity_receiver_collection.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_receiver_collection.xml
@@ -257,9 +257,9 @@
 
                 <TextView
                     android:id="@+id/textView7"
-                    android:layout_width="match_parent"
-                    android:layout_height="fill_parent"
-                    android:layout_weight="1"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.40"
                     android:layout_marginLeft="20dp"
                     android:text="Full (L):"
                     android:gravity="center_vertical"
@@ -268,8 +268,9 @@
 
                 <EditText
                     android:id="@+id/editText1"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_weight="0.60"
                     android:ems="10"
                     android:inputType="numberDecimal" />
 
@@ -285,9 +286,9 @@
 
                 <TextView
                     android:id="@+id/textView8"
-                    android:layout_width="match_parent"
-                    android:layout_height="fill_parent"
-                    android:layout_weight="1"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.40"
                     android:layout_marginLeft="20dp"
                     android:text="Empty (L):"
                     android:gravity="center_vertical"
@@ -296,8 +297,9 @@
 
                 <EditText
                     android:id="@+id/editText2"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
+                    android:layout_weight="0.60"
                     android:ems="10"
                     android:inputType="numberDecimal" />
 

--- a/MilkBuddy/app/src/main/res/layout/activity_receiver_collection.xml
+++ b/MilkBuddy/app/src/main/res/layout/activity_receiver_collection.xml
@@ -272,6 +272,7 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0.60"
                     android:ems="10"
+                    android:maxLength="5"
                     android:inputType="numberDecimal" />
 
             </TableRow>
@@ -301,6 +302,7 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="0.60"
                     android:ems="10"
+                    android:maxLength="5"
                     android:inputType="numberDecimal" />
 
             </TableRow>


### PR DESCRIPTION
On the receiver collection page, ensure that Empty (L): is on one line. Check on smaller devices like the Nexus One.

I also limited the number of characters for the milk quantity input to 5, meaning that quantities with only 2 decimal places can be inputted (i.e. 25.45). The decimal place counts as one character. Let me know if the max number of characters should be changed.

Also please let me know if you think that characters on other fields such as Comments on the Farmer/Receiver Collection pages or the Guest Transporter Login should have a limit. Since we are not sure how comprehensive a transporter's comments will be, I did not put a limit on how much they can write. I am also not sure if there should be a limit on a guest transporter's name and their phone number.